### PR TITLE
improve fixdsv speed

### DIFF
--- a/dsv.ijs
+++ b/dsv.ijs
@@ -136,8 +136,8 @@ fixdsv=: 3 : 0
       dat=. dat charsub~ ,sd,.s
       sd=. s
     end.
-    b=. dat e. LF
-    c=. ~:/\ dat e. sd
+    b=. dat = LF
+    c=. ~:/\ +./ (,sd) =/ dat
     msk=. b > c
     > msk <@(x&chopstring);._2 ydrp
   else.                          NB. no string delimiter

--- a/dsv.ijs
+++ b/dsv.ijs
@@ -137,7 +137,7 @@ fixdsv=: 3 : 0
       sd=. s
     end.
     b=. dat = LF
-    c=. ~:/\ +./ (,sd) =/ dat
+    c=. ~:/\ dat = {.sd
     msk=. b > c
     > msk <@(x&chopstring);._2 ydrp
   else.                          NB. no string delimiter

--- a/source/fromdsv.ijs
+++ b/source/fromdsv.ijs
@@ -24,7 +24,7 @@ fixdsv=: 3 : 0
       sd=. s
     end.
     b=. dat = LF
-    c=. ~:/\ +./ (,sd) =/ dat
+    c=. ~:/\ dat = {.sd
     msk=. b > c
     > msk <@(x&chopstring);._2 ydrp
   else.                          NB. no string delimiter

--- a/source/fromdsv.ijs
+++ b/source/fromdsv.ijs
@@ -23,8 +23,8 @@ fixdsv=: 3 : 0
       dat=. dat charsub~ ,sd,.s
       sd=. s
     end.
-    b=. dat e. LF
-    c=. ~:/\ dat e. sd
+    b=. dat = LF
+    c=. ~:/\ +./ sd =/ dat
     msk=. b > c
     > msk <@(x&chopstring);._2 ydrp
   else.                          NB. no string delimiter

--- a/source/fromdsv.ijs
+++ b/source/fromdsv.ijs
@@ -24,7 +24,7 @@ fixdsv=: 3 : 0
       sd=. s
     end.
     b=. dat = LF
-    c=. ~:/\ +./ sd =/ dat
+    c=. ~:/\ +./ (,sd) =/ dat
     msk=. b > c
     > msk <@(x&chopstring);._2 ydrp
   else.                          NB. no string delimiter


### PR DESCRIPTION
Writing `fixdsv` to use `=` instead of `e.` seems to get a decent performance improvement when calculating masks. The tests pass, though I am getting a failure in the following lines with or without these changes, where `nempty` is 2 and `nwrongtype` 3.

```J
  nempty=. +/0=,#&> b2
  nwrongtype=. +/0=,(3!:0 each b2) = 3!:0 each makenum fixdsv delimitarray b2
  assert. nempty=nwrongtype NB. empty cells change type but not problem
```
Simple bench:

```J
   0!:1 < 'bench.ijs'
   # dat1 =: 1!:1 < 'data/csv1.csv'
62085027
   # dat2 =: 1!:1 < 'data/csv2.csv'
91614581
   # dat3 =: 1!:1 < 'data/csv3.csv'
236024379
   cmd =: > 'pdsv '&, &.> ;: 'dat1 dat2 dat3'
   load 'tables/dsv'
   pdsv =: (',';'"')&fixdsv
   ]cur =: 6!:2"1 cmd
1.8822 2.73893 6.78034
   load '../tables_dsv/dsv.ijs'
   pdsv =: (',';'"')&fixdsv
   ]df0 =: 6!:2"1 cmd
1.68833 2.4902 5.991
   load '../base9/main/strings.ijs'
   pdsv =: (',';'"')&fixdsv
   ]df1 =: 6!:2"1 cmd
1.58572 2.27411 5.3764
   cur (- % [) df0
0.103005 0.0908153 0.116415
   cur (- % [) df1
0.157519 0.169711 0.207059
```